### PR TITLE
Created A static managers prefab, for streamlining purposes

### DIFF
--- a/FA23 - 372/Assets/Prefabs/StaticManagers.prefab
+++ b/FA23 - 372/Assets/Prefabs/StaticManagers.prefab
@@ -1,0 +1,88 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5725323081168251565
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 425752651595243879}
+  - component: {fileID: 352282471641655481}
+  - component: {fileID: 6916374592651308109}
+  - component: {fileID: 3497024805389046465}
+  m_Layer: 0
+  m_Name: StaticManagers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &425752651595243879
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5725323081168251565}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &352282471641655481
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5725323081168251565}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7d8c5077ba4bd4a4baa30d8c9a337645, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  silenceManagers: 0
+  waveCount: 0
+  playerHealth: 100
+  playerScore: 0
+--- !u!114 &6916374592651308109
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5725323081168251565}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 04083b44d97a9154e915b3093297e7ba, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  hintVariationRange: 5
+  alertMin: 0
+  alertMax: 1
+  alertThreshold: 0.5
+  waypoints: []
+--- !u!114 &3497024805389046465
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5725323081168251565}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: afeb351660eb7d94ea9451b4395e7982, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  knightPrefab: {fileID: 6251559957116596838, guid: cb568334f3091974eb0ee433e6950905, type: 3}
+  bowmenPrefab: {fileID: 0}
+  buglerPrefab: {fileID: 0}
+  UseNewQuotaSystem: 0
+  knightWaveQuotas: 
+  bowmenWaveQuotas: 
+  buglerWaveQuotas: 

--- a/FA23 - 372/Assets/Prefabs/StaticManagers.prefab.meta
+++ b/FA23 - 372/Assets/Prefabs/StaticManagers.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0fed766c6e5005240a34a397c7722c67
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FA23 - 372/Assets/Scripts/Managers/AIOverseer.cs
+++ b/FA23 - 372/Assets/Scripts/Managers/AIOverseer.cs
@@ -37,15 +37,27 @@ public class AIOverseer : MonoBehaviour
 
     private void Start()
     {
+        if (GameManager.enabledGameManager.silenceManagers) return;
         hintLocation = GenerateNewHintLocation();
     }
 
-    public void ReportAgentAddition(GameObject agentToAdd) { activeAgents.Add(agentToAdd); }
-    public void ReportAgentSubtraction(GameObject agentToSubtract) { activeAgents.Remove(agentToSubtract);
+    public void ReportAgentAddition(GameObject agentToAdd) {
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        activeAgents.Add(agentToAdd); 
+    }
+    public void ReportAgentSubtraction(GameObject agentToSubtract) {
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        activeAgents.Remove(agentToSubtract);
         if (activeAgents.Count < 1) SignalWaveSpawn();
     }
-    public void ReportFightingAgentAddition(GameObject agentToAdd) { fightingAgents.Add(agentToAdd); }
-    public void ReportFightingAgentSubtraction(GameObject agentToSubtract) { fightingAgents.Remove(agentToSubtract); }
+    public void ReportFightingAgentAddition(GameObject agentToAdd) {
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        fightingAgents.Add(agentToAdd); 
+    }
+    public void ReportFightingAgentSubtraction(GameObject agentToSubtract) {
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        fightingAgents.Remove(agentToSubtract); 
+    }
 
     private Vector3 GenerateNewHintLocation()
     {
@@ -57,6 +69,7 @@ public class AIOverseer : MonoBehaviour
 
     public void GiveHintToAgent(NavMeshAgent agent)
     {
+        if (GameManager.enabledGameManager.silenceManagers) return;
         hintLocation = GenerateNewHintLocation();
         agent.destination = hintLocation;
     }
@@ -78,12 +91,14 @@ public class AIOverseer : MonoBehaviour
 
     public void SignalDodgeToFightingAgents()
     {
-        foreach(GameObject g in fightingAgents) if(Random.Range(alertMin, alertMax) > alertThreshold) { g.GetComponent<IAgent>().SetBehaviorState(0); }   //placeholder parameter    
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        foreach (GameObject g in fightingAgents) if(Random.Range(alertMin, alertMax) > alertThreshold) { g.GetComponent<IAgent>().SetBehaviorState(0); }   //placeholder parameter    
     }
 
     public void SignalRushToFightingAgents()
     {
-        foreach(GameObject g in fightingAgents) if(Random.Range(alertMin, alertMax) > alertThreshold) { g.GetComponent<IAgent>().SetBehaviorState(1); }   //placeholder parameter
+        if (GameManager.enabledGameManager.silenceManagers) return;
+        foreach (GameObject g in fightingAgents) if(Random.Range(alertMin, alertMax) > alertThreshold) { g.GetComponent<IAgent>().SetBehaviorState(1); }   //placeholder parameter
     }
 
 }

--- a/FA23 - 372/Assets/Scripts/Managers/GameManager.cs
+++ b/FA23 - 372/Assets/Scripts/Managers/GameManager.cs
@@ -6,6 +6,8 @@ using UnityEngine.AI;
 public class GameManager : MonoBehaviour
 {
     public static GameManager enabledGameManager = null;
+    [Tooltip("Check this box to make any static managers in the scene not execute their Start functions, or other public functions.")]
+    public bool silenceManagers = false;
     [HideInInspector] public int waveCount = 0;
     [HideInInspector] public int playerHealth = 100;
     [HideInInspector] public int playerScore = 0;
@@ -19,6 +21,7 @@ public class GameManager : MonoBehaviour
 
     private void Start()
     {
+        if (silenceManagers) return;
         GameObject[] allSpawnLocations = GameObject.FindGameObjectsWithTag("SpawnLocation");
         foreach (GameObject g in allSpawnLocations)
             if (g.GetComponent<SpawnLocation>().open)
@@ -28,6 +31,7 @@ public class GameManager : MonoBehaviour
 
 
      public void OnPlayerWeaponStateChange (GunState state) {
+        if (silenceManagers) return;
           switch (state) {
               case GunState.READYTOFIRE:
                   AIOverseer.overseer.SignalDodgeToFightingAgents();

--- a/FA23 - 372/Assets/Scripts/Managers/SpawnManager.cs
+++ b/FA23 - 372/Assets/Scripts/Managers/SpawnManager.cs
@@ -49,16 +49,19 @@ public class SpawnManager : MonoBehaviour
 
     public void AddOpenSpawnLocation(SpawnLocation newLocation)
     {
+        if (GameManager.enabledGameManager.silenceManagers) return;
         openSpawnLocations.Add(newLocation);
     }
 
     private void RemoveOpenSpawnLocation(SpawnLocation location)
     {
+        if (GameManager.enabledGameManager.silenceManagers) return;
         openSpawnLocations.Remove(location);
     }
 
     public void SpawnWave()
     {
+        if (GameManager.enabledGameManager.silenceManagers) return;
         if (!UseNewQuotaSystem) OldQuotaSystem();
         else NewQuotaSystem();
     }


### PR DESCRIPTION
GameManager also now has a checkbox called 'silence managers'. Basically, if you need the scripts in the scene, but have no intention of fully wiring them up, check the box to prevent any annoying error messages.